### PR TITLE
Updated mingw64 and Readme.md

### DIFF
--- a/Windows/README.md
+++ b/Windows/README.md
@@ -33,7 +33,7 @@ It contains all the documentation for making NGHDL executable (using PyInstaller
 
 			$ pip install pyinstaller
 			$ pip install setuptools
-			$ pip install PyQt5
+			$ pip install PyQt5==5.9.2
 
 7. Test whether only NGHDL dependencies are available or not:
 


### PR DESCRIPTION
Added 5 DLL files to mingw64 to eliminate Windows OS errors and to ensure the smooth running of operations:
1. opengl32sw.dll
2. vcruntime140_1.dll
3. d3dcompiler_47.dll
4. libEGL.dll
5. libGLESv2.dll

Existing mingw64 file size: 16,329 KB
Updated mingw64 file size:  26,692 KB
