### PR TITLE
Updated mingw64 and Readme.md

### DIFF
--- a/Windows/README.md
+++ b/Windows/README.md
@@ -33,7 +33,7 @@ It contains all the documentation for making NGHDL executable (using PyInstaller
 
 			$ pip install pyinstaller
 			$ pip install setuptools
-			$ pip install PyQt5
+			$ pip install PyQt5==5.9.2
 
 7. Test whether only NGHDL dependencies are available or not:
 


### PR DESCRIPTION
Modified by Manasi Yadav, Sumanto Kar on 17.08.2021

Specified the version of PyQt5 to be installed. 

The Bluetooth API module implemented in the existing version of PyQt5 is not supported by the Windows 8 OS, due to which eSim 2.1 crashes in Windows 8. To fix this, PyQt5 is downgraded to a version lower than 5.10 i.e. 5.9.2.