### PR TITLE
Add support for Ubuntu 25.04 in installer script

### DIFF
--- a/Ubuntu/install-nghdl.sh
+++ b/Ubuntu/install-nghdl.sh
@@ -54,7 +54,7 @@ function installDependency
     sudo apt remove -y llvm llvm-dev
 
     echo "Installing LLVM........................................"
-    sudo apt install -y llvm llvm-dev
+    sudo apt install -y llvm-18 llvm-18-dev
 
     echo "Installing Clang.........................................."
     sudo apt install -y clang
@@ -64,7 +64,7 @@ function installDependency
   
     # Specific dependency for canberra-gtk modules
     echo "Installing Gtk Canberra modules..........................."
-    sudo apt install -y libcanberra-gtk-module libcanberra-gtk3-module
+    sudo apt install -y libcanberra-gtk3-module
 
     # Specific dependency for nvidia graphic cards
     echo "Installing graphics dependency for Ngspice source build"
@@ -101,7 +101,7 @@ function installGHDL
     echo "Configuring $ghdl build as per requirements"
     chmod +x configure
     # Other configure flags can be found at - https://github.com/ghdl/ghdl/blob/master/configure
-    ./configure --with-llvm-config=/usr/bin/llvm-config
+    ./configure --with-llvm-config=/usr/bin/llvm-config-18
     echo "Building the install file for $ghdl LLVM"
     make -j$(nproc)
     sudo make install


### PR DESCRIPTION
Summary of changes:

- llvm 
  - Issue: GHDL doesn't support the latest version of llvm (i.e., llvm-20.1)
  - Fix: modified the installer script to install llvm-18.1
- InstallGHDL
  - Issue: Uses `usr/bin/llvm-config` as the configuration file (because it assumes llvm-20.1) 
    `./configure --with-llvm-config=/usr/bin/llvm-config-18`
  - Fix: replace that with the correct version: `/usr/bin/llvm-config-18`
- Gtk Canberra
  - Issue: libcanberra-gtk-module is not available to be installed in Ubuntu-25.04
  - Fix: Only install libcanberra-gtk3-module
