### PR TITLE
Fixes issue #XX - Fix CRLF line endings in shell scripts on Windows/WSL

### DIFF
--- a/src/model_generation.py
+++ b/src/model_generation.py
@@ -1063,7 +1063,8 @@ class ModelGeneration:
         self.digital_home = self.parser.get('NGHDL', 'DIGITAL_MODEL')
         self.digital_home = os.path.join(self.digital_home, "ghdl")
 
-        start_server = open('start_server.sh', 'w')
+        # Force Unix line endings (LF) to ensure compatibility with bash on WSL/Linux
+        start_server = open('start_server.sh', 'w', newline='\n')
 
         start_server.write("#!/bin/bash\n\n")
         start_server.write(
@@ -1114,7 +1115,8 @@ class ModelGeneration:
 
         # ########### Creating and writing in sock_pkg_create.sh ########### #
 
-        sock_pkg_create = open('sock_pkg_create.sh', 'w')
+        # Force Unix line endings (LF) to ensure compatibility with bash on WSL/Linux
+        sock_pkg_create = open('sock_pkg_create.sh', 'w', newline='\n')
 
         sock_pkg_create.write("#!/bin/bash\n\n")
         sock_pkg_create.write(


### PR DESCRIPTION
## Summary
Fixed CRLF line ending issue in [model_generation.py](cci:7://file:///c:/Users/aksha/Desktop/nghdl/src/model_generation.py:0:0-0:0) that caused VHDL simulations to fail on Windows/WSL.

## Changes
- Added `newline='\n'` parameter to `open()` calls when creating [start_server.sh](cci:7://file:///c:/Users/aksha/Desktop/nghdl/fixed_start_server.sh:0:0-0:0) and `sock_pkg_create.sh`
- This forces Unix line endings (LF) on all platforms

## Testing
Tested on Windows 11 with WSL Ubuntu 24.04. VHDL simulations (full_adder) now work correctly.

## Related Issue
Fixes #XX

Author: Akshay Rukade <akshayrukade01@gmail.com>